### PR TITLE
Implement auto-indexed predecr/postincr, fix XPPC.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,10 +90,7 @@ task copySleighSources(type: Sync) {
     dependsOn(compileSleigh)
 }
 
-
-// tasks.named('buildExtension') {
-// }
-
+// TODO(siggi): This needs to depend on the slaspec somehow.
 tasks.named('test') {
     useJUnitPlatform()
 

--- a/data/languages/scmp.slaspec
+++ b/data/languages/scmp.slaspec
@@ -235,7 +235,7 @@ PTR: disp8(op_ptr) is op_ptr; disp8 {
   <nojmp>
 }
 
-:DLY is op0_7 = 0x8F {
+:DLY imm8 is op0_7 = 0x8F; imm8 {
   # Just a NOP for our purposes.
   goto inst_next;
 }

--- a/data/languages/scmp.slaspec
+++ b/data/languages/scmp.slaspec
@@ -83,15 +83,27 @@ EA: disp8(op_ptr) is op_m = 0 & op_ptr; imm8 != 0x80 & disp8 {
 # nonsensical STI.
 EA: @disp8(op_ptr) is op_m = 1 & op_ptr &
     (op_ptr = 1 | op_ptr = 2 | op_ptr = 3); imm8 != 0x80 & disp8 {
-  # TODO(siggi): Deal with pre-decrement and post-increment.
-  local ret:2;
-  dispEa(ret, op_ptr, disp8);
-  op_ptr = ret;
+  # Compute the EA.
+  local tmp:2;
+  dispEa(tmp, op_ptr, disp8);
+
+  local ret:2 = op_ptr;
+  local disp:1 = disp8;
+  if (disp s>= 0)
+    goto <post_incr>;
+
+  # The pre-decrement case returns the new EA.
+  ret = tmp;
+
+<post_incr>
+  # Update the ptr register to the new value in either case.
+  op_ptr = tmp;
   export ret;
 }
 
 # Special cases for E-relative.
 EA: E(op_ptr) is op_m = 0 & op_ptr & E; imm8 = 0x80 {
+  # TODO(siggi): Does this also do pre-decrement and post-increment?
   local ret:2;
   dispEa(ret, op_ptr, sext(E));
   export ret;

--- a/data/languages/scmp.slaspec
+++ b/data/languages/scmp.slaspec
@@ -245,7 +245,7 @@ PTR: disp8(op_ptr) is op_ptr; disp8 {
 }
 
 :XAE is op0_7 = 0x01 {
-  local tmp:1 = AC;
+  local tmp:1 = E;
   E = AC;
   AC = tmp;
 }

--- a/data/languages/scmp.slaspec
+++ b/data/languages/scmp.slaspec
@@ -290,8 +290,12 @@ PTR: disp8(op_ptr) is op_ptr; disp8 {
 }
 
 :XPPC op_ptr is op2_7 = 0x0F & op_ptr {
-  local tmp:2 = op_ptr;
-  op_ptr = inst_next;
+  # This instruction doesn't behave as described in the manual.
+  # Rather than incrementing PC before the swap, it increments
+  # it after the swap. The end result is the same, except the
+  # pointer register must always be one short of the destination.
+  local tmp:2 = (op_ptr + 1) & 0x0FFF;
+  op_ptr = inst_start;
   goto [tmp];
 }
 

--- a/src/test/java/is/sort/scmp/AbstractEmulatorTest.java
+++ b/src/test/java/is/sort/scmp/AbstractEmulatorTest.java
@@ -122,12 +122,21 @@ public abstract class AbstractEmulatorTest extends AbstractIntegrationTest {
 		return emulator.readMemory(address(addr), length);
 	}
 
-	protected byte readByte(int addr) {
-		return read(addr, 1)[0];
+	protected int readByte(int addr) {
+		return read(addr, 1)[0] & 0xFF;
 	}
 
 	protected void stepFrom(int addr) {
 		setPC(addr);
+		try {
+			emulator.step(TaskMonitor.DUMMY);
+		}
+		catch (CancelledException e) {
+			fail("Failed to step.", e);
+		}
+	}
+
+	protected void step() {
 		try {
 			emulator.step(TaskMonitor.DUMMY);
 		}

--- a/src/test/java/is/sort/scmp/DisassemblySCMPTest.java
+++ b/src/test/java/is/sort/scmp/DisassemblySCMPTest.java
@@ -263,7 +263,7 @@ public class DisassemblySCMPTest extends AbstractIntegrationTest {
 
 	@Test
 	public void DLY() {
-		assertDisassemblesTo("DLY", 0x8F);
+		assertDisassemblesTo("DLY 0x8f", 0x8F, 0x8F);
 	}
 
 	@Test

--- a/src/test/java/is/sort/scmp/EmulatorSCMPTest.java
+++ b/src/test/java/is/sort/scmp/EmulatorSCMPTest.java
@@ -171,6 +171,16 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 	}
 
 	@Test
+	public void XAE() {
+		write(0x100, 0x1);	// XAE
+		setAC(0x01);
+		setE(0x02);
+		stepFrom(0x100);
+		assertEquals(0x2, getAC());
+		assertEquals(0x1, getE());
+	}
+
+	@Test
 	public void XPAL() {
 		write(0x100, 0x31);  // XPAL P1.
 
@@ -201,6 +211,7 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 		setP1(0x0203);
 		stepFrom(0x0100);
 
+		// PC is incremented post-exchange.
 		assertEquals(0x0204, getPC());
 		assertEquals(0x0100, getP1());
 

--- a/src/test/java/is/sort/scmp/EmulatorSCMPTest.java
+++ b/src/test/java/is/sort/scmp/EmulatorSCMPTest.java
@@ -26,6 +26,40 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 	}
 
 	@Test
+	public void AutoIndexedEA() {
+		final int PC = 0x0100;
+
+		// Post-increment:
+		// 	ST @0x10(P1)
+		// 	LD @0x-10(P1)
+		// Pre-decrement:
+		//	ST @-0x10(P1)
+		//	LD @0x10(P1)
+		write(PC, 0xCD, 0x10, 0xC5, 0xF0, 0xCD, 0xF0, 0xC5, 0x10);
+
+		setAC(0xAA);
+		setP1(0x1000);
+		stepFrom(PC);
+		assertEquals(0x1010, getP1());
+		assertEquals(0xAA, readByte(0x1000));
+
+		setAC(0x00);
+		step();
+		assertEquals(0x1000, getP1());
+		assertEquals(0xAA, getAC());
+
+		step();
+		assertEquals(0x1FF0, getP1());
+		assertEquals(0xAA, readByte(0x1FF0));
+
+		setAC(0x00);
+		step();
+		step();
+		assertEquals(0x1000, getP1());
+		assertEquals(0xAA, getAC());
+	}
+
+	@Test
 	public void NOP() {
 		setAC(0x00);
 		setSR(0x00);
@@ -48,7 +82,7 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 
 	@Test
 	public void LD_PCRel() {
-		int PC = 0x8100;
+		final int PC = 0x8100;
 		write(PC, 0xC0, 0x10);
 		write(0x8112, 0xFF);
 		stepFrom(PC);
@@ -57,15 +91,14 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 
 	@Test
 	public void JMP_PCRel() {
-		int PC = 0x8100;
+		final int PC = 0x8100;
 		// PC-relative JMP.
 		write(PC, 0x90, 0x10, 0x90, 0xFF);
 		stepFrom(PC);
 		assertEquals(PC + 0x12, getPC());
 
-		PC += 2;
-		stepFrom(PC);
-		assertEquals(PC + 0x01, getPC());
+		stepFrom(PC + 2);
+		assertEquals(PC + 0x03, getPC());
 	}
 
 	@Test
@@ -146,7 +179,7 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 		stepFrom(0x100);
 
 		assertEquals(0x03, getAC());
-		assertEquals(0x0201, getP1());	
+		assertEquals(0x0201, getP1());
 	}
 
 	@Test
@@ -158,7 +191,7 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 		stepFrom(0x0100);
 
 		assertEquals(0x02, getAC());
-		assertEquals(0x0103, getP1());	
+		assertEquals(0x0103, getP1());
 	}
 
 	@Test
@@ -169,7 +202,7 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 		stepFrom(0x0100);
 
 		assertEquals(0x0203, getPC());
-		assertEquals(0x0101, getP1());	
-		
+		assertEquals(0x0101, getP1());
+
 	}
 }

--- a/src/test/java/is/sort/scmp/EmulatorSCMPTest.java
+++ b/src/test/java/is/sort/scmp/EmulatorSCMPTest.java
@@ -201,8 +201,8 @@ public class EmulatorSCMPTest extends AbstractEmulatorTest {
 		setP1(0x0203);
 		stepFrom(0x0100);
 
-		assertEquals(0x0203, getPC());
-		assertEquals(0x0101, getP1());
+		assertEquals(0x0204, getPC());
+		assertEquals(0x0100, getP1());
 
 	}
 }


### PR DESCRIPTION
Turns out XPPC doesn't work the way it's documented, as it increments PC after the register switch.
This means the destination register needs to contain the destination less one, but otherwise everything works out.
Fix DLY to use an imm8. Fix XEA to actually switch AC and E.