### PR TITLE
Play with the specs a little.

### DIFF
--- a/data/languages/scmp.cspec
+++ b/data/languages/scmp.cspec
@@ -11,7 +11,7 @@
   </global>
   <stackpointer register="P2" space="ram"/>
   <default_proto>
-    <prototype name="__asmA" extrapop="2" stackshift="2" strategy="register">
+    <prototype name="default" extrapop="0" stackshift="0" strategy="register">
       <input>
         <pentry minsize="1" maxsize="1">
           <register name="AC"/>
@@ -23,8 +23,8 @@
         </pentry>
       </output>
       <unaffected>
-        <register name="P1"/>
         <register name="P2"/>
+        <register name="P3"/>
       </unaffected>
     </prototype>
   </default_proto>

--- a/data/languages/scmp.cspec
+++ b/data/languages/scmp.cspec
@@ -22,8 +22,12 @@
           <register name="AC"/>
         </pentry>
       </output>
+      <returnaddress>
+        <register name="P3"/>
+      </returnaddress>
       <unaffected>
         <register name="P2"/>
+<!-- TODO(siggi): Does this make sense? -->
         <register name="P3"/>
       </unaffected>
     </prototype>

--- a/data/languages/scmp.pspec
+++ b/data/languages/scmp.pspec
@@ -14,6 +14,6 @@
     <register name="P3"/>
   </register_data>
   <default_symbols>
-    <symbol name="RST" address="ram:0000" entry="true"/>
+    <symbol name="RST" address="ram:0001" entry="true"/>
   </default_symbols>
 </processor_spec>

--- a/data/languages/scmp.slaspec
+++ b/data/languages/scmp.slaspec
@@ -376,7 +376,6 @@ PTRJmp: E(op_ptr) is op_ptr & E; imm8 = 0x80 & disp8 {
 
 # TODO(siggi): Special case for PC!
 :XPAH op_ptr is op2_7 = 0x0D & op_ptr {
-  # TODO(siggi): Does this need special casing for PC?
   local tmp:1 = op_ptr[8,8];
   op_ptr[8,8] = AC;
   AC = tmp;


### PR DESCRIPTION
Rename __asm calling convention to default.
Try to add a <returnaddress> declaration, which doesn't seem to change much, if anything.
Move RST to ram:0x0001.
Scrub a stray comment.