### PR TITLE
Build cleanup.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ buildExtension {
     exclude '.github/**'
     exclude 'gradle/**'
     exclude 'eclipse/**'
+    exclude 'README.md'
 
     dependsOn(compileSleigh)
     dependsOn(copySleighSources)


### PR DESCRIPTION
Stop building .sla files into sources.
Make sure tests run on .slaspec changes.